### PR TITLE
Remove the dependency on Guava for easier j2cl compatibility.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,17 +57,6 @@
       <version>${safehtml.version}</version>
     </dependency>
 
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>${guava.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava-gwt</artifactId>
-      <version>${guava.version}</version>
-    </dependency>
-
     <!-- only for test -->
     <dependency>
       <groupId>junit</groupId>

--- a/src/main/java/org/gwtproject/safecss/shared/SafeStylesHostedModeUtilsJvm.java
+++ b/src/main/java/org/gwtproject/safecss/shared/SafeStylesHostedModeUtilsJvm.java
@@ -15,10 +15,8 @@
  */
 package org.gwtproject.safecss.shared;
 
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
-
 import org.gwtproject.safecss.shared.annotations.GwtIncompatible;
+import org.gwtproject.safecss.shared.annotations.VisibleForTesting;
 
 import java.util.HashMap;
 import java.util.Stack;
@@ -254,7 +252,9 @@ public class SafeStylesHostedModeUtilsJvm
   public static void maybeCheckValidStyleName(String name) {
     if (forceCheck) {
       String errorText = isValidStyleName(name);
-      Preconditions.checkArgument(errorText == null, errorText);
+      if (errorText != null) {
+        throw new IllegalArgumentException(errorText);
+      }
     } else {
       assert isValidStyleName(name) == null : isValidStyleName(name);
     }
@@ -271,7 +271,9 @@ public class SafeStylesHostedModeUtilsJvm
   public static void maybeCheckValidStyleValue(String value) {
     if (forceCheck) {
       String errorText = isValidStyleValue(value);
-      Preconditions.checkArgument(errorText == null, errorText);
+      if (errorText != null) {
+        throw new IllegalArgumentException(errorText);
+      }
     } else {
       assert isValidStyleValue(value) == null : isValidStyleValue(value);
     }

--- a/src/main/java/org/gwtproject/safecss/shared/SafeStylesUtils.java
+++ b/src/main/java/org/gwtproject/safecss/shared/SafeStylesUtils.java
@@ -38,7 +38,6 @@ import org.gwtproject.dom.style.shared.Visibility;
 import org.gwtproject.dom.style.shared.WhiteSpace;
 import org.gwtproject.safehtml.shared.SafeUri;
 
-
 /**
  * Utility class containing static methods for creating {@link SafeStyles}.
  */

--- a/src/main/java/org/gwtproject/safecss/shared/annotations/VisibleForTesting.java
+++ b/src/main/java/org/gwtproject/safecss/shared/annotations/VisibleForTesting.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2011 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.gwtproject.safecss.shared.annotations;
+
+/**
+ * Marks a method as visible not because it is part of the API, but because it is needed to be visible to make the
+ * containing class possible to test.
+ */
+public @interface VisibleForTesting {
+}


### PR DESCRIPTION
At this time, guava-gwt doesn't work in j2cl as it is in maven, since
you need to include both guava and guava-gwt on your classpath to compile
correctly in GWT2. Changing this could be done in a few ways, like providing
two different gwt-safecss poms (once a guava-j2cl existed), or since we only
need guava for a one method and one annotation, we can simply cut the
dependency outright.

Instead of this patch, one option is, as above, building a different copy of this project for gwt2 vs gwt3, at least until guava jars in maven behave nicely with respect to gwt.